### PR TITLE
show the unapproved files

### DIFF
--- a/guide.go
+++ b/guide.go
@@ -31,11 +31,17 @@ func newNotificationComment(rs *reviewSummary, s, botName string) notificationCo
 
 type notificationComment struct {
 	rs      *reviewSummary
+	rr      *reviewResult
 	oldTips string
 	botName string
 }
 
-func (n notificationComment) genApproveTips(num int, approvers, ownersFiles, unApprovedFiles []string) string {
+func (n notificationComment) genApproveTips(approvers, ownersFiles []string) string {
+	an := ""
+	if n.rr.needApproveNum > 0 {
+		an = fmt.Sprintf("%d ", n.rr.needApproveNum)
+	}
+
 	of := ""
 	if len(ownersFiles) > 0 {
 		sort.Strings(ownersFiles)
@@ -47,19 +53,19 @@ func (n notificationComment) genApproveTips(num int, approvers, ownersFiles, unA
 	}
 
 	uf := ""
-	if len(unApprovedFiles) > 0 {
-		sort.Strings(unApprovedFiles)
+	if len(n.rr.unApprovedFiles) > 0 {
+		sort.Strings(n.rr.unApprovedFiles)
 
 		uf = fmt.Sprintf(
 			"\nThe unapproved files are as bellow.\n- %s\n",
-			strings.Join(unApprovedFiles, "\n- "),
+			strings.Join(n.rr.unApprovedFiles, "\n- "),
 		)
 	}
 
 	return fmt.Sprintf(
-		"%s, it still needs approvers to comment /approve.%s%s\nI suggest these approvers( %s ) to approve your PR.\nYou can assign the PR to them by writing a comment like this `/assign @%s`. Please, replace `%s` with the correct approver's name.",
+		"%s, it still needs %sapprovers to comment /approve.%s%s\nI suggest these approvers( %s ) to approve your PR.\nYou can assign the PR to them by writing a comment like this `/assign @%s`. Please, replace `%s` with the correct approver's name.",
 		notificationApprovePart2,
-		uf, of,
+		an, uf, of,
 		toReviewerList(approvers),
 		n.botName,
 		n.botName,
@@ -159,13 +165,13 @@ func (n notificationComment) approvedComment(num int, suggestedReviewers []strin
 	)
 }
 
-func (n notificationComment) lgtmComment(suggestedApprovers, ownersFiles, unApprovedFiles []string) string {
+func (n notificationComment) lgtmComment(suggestedApprovers, ownersFiles []string) string {
 	s := n.reviewInfo()
 	if s != "" {
 		s = notificationLineSpliter + s
 	}
 
-	s1 := n.getPart2OfApproved(suggestedApprovers, ownersFiles, unApprovedFiles)
+	s1 := n.getPart2OfApproved(suggestedApprovers, ownersFiles)
 
 	return fmt.Sprintf(
 		"%s %s. In order to pass review, it still needs **approved** label.%s%s",
@@ -197,11 +203,9 @@ func (n notificationComment) reviewInfo() string {
 	return s + s1
 }
 
-func (n notificationComment) getPart2OfApproved(suggestedApprovers, ownersFiles, unApprovedFiles []string) string {
-	if num := len(suggestedApprovers); num > 0 {
-		return n.genPart2(
-			n.genApproveTips(num, suggestedApprovers, ownersFiles, unApprovedFiles),
-		)
+func (n notificationComment) getPart2OfApproved(suggestedApprovers, ownersFiles []string) string {
+	if len(suggestedApprovers) > 0 {
+		return n.genPart2(n.genApproveTips(suggestedApprovers, ownersFiles))
 	}
 
 	if !containsSuggestedApprover(n.oldTips) {

--- a/models.go
+++ b/models.go
@@ -173,14 +173,15 @@ func checkReviewCommand(
 }
 
 type reviewResult struct {
-	isRejected  bool
-	isApproved  bool
-	isLGTM      bool
-	isLBTM      bool
-	needLGTMNum int
+	isRejected      bool
+	isApproved      bool
+	isLGTM          bool
+	isLBTM          bool
+	needLGTMNum     int
+	unApprovedFiles []string
 }
 
-func genReviewResult(r reviewSummary, allFilesApproved func([]string, int) bool, cfg reviewConfig) reviewResult {
+func genReviewResult(r reviewSummary, unApprovedFiles func([]string, int) []string, cfg reviewConfig) reviewResult {
 	rr := reviewResult{}
 
 	if len(r.disagreedApprovers) > 0 {
@@ -190,7 +191,8 @@ func genReviewResult(r reviewSummary, allFilesApproved func([]string, int) bool,
 
 	an := len(r.agreedApprovers)
 
-	if allFilesApproved(r.agreedApprovers, cfg.NumberOfApprovers) {
+	rr.unApprovedFiles = unApprovedFiles(r.agreedApprovers, cfg.NumberOfApprovers)
+	if len(rr.unApprovedFiles) == 0 {
 		rr.isApproved = an >= cfg.TotalNumberOfApprovers
 	}
 

--- a/models.go
+++ b/models.go
@@ -178,6 +178,7 @@ type reviewResult struct {
 	isLGTM          bool
 	isLBTM          bool
 	needLGTMNum     int
+	needApproveNum  int
 	unApprovedFiles []string
 }
 
@@ -192,8 +193,14 @@ func genReviewResult(r reviewSummary, unApprovedFiles func([]string, int) []stri
 	an := len(r.agreedApprovers)
 
 	rr.unApprovedFiles = unApprovedFiles(r.agreedApprovers, cfg.NumberOfApprovers)
-	if len(rr.unApprovedFiles) == 0 {
-		rr.isApproved = an >= cfg.TotalNumberOfApprovers
+	if n := len(rr.unApprovedFiles); n == 0 {
+		if an >= cfg.TotalNumberOfApprovers {
+			rr.isApproved = true
+		} else {
+			rr.needApproveNum = cfg.TotalNumberOfApprovers - an
+		}
+	} else if n > 5 {
+		rr.unApprovedFiles = rr.unApprovedFiles[:5]
 	}
 
 	rn := an + len(r.agreedReviewers)

--- a/stats.go
+++ b/stats.go
@@ -33,7 +33,7 @@ func (rs reviewStats) StatReview(
 
 	r := genReviewSummary(commands)
 
-	return r, genReviewResult(r, rs.pr.areAllFilesApproved, rs.cfg)
+	return r, genReviewResult(r, rs.pr.unApprovedFiles, rs.cfg)
 }
 
 func (rs reviewStats) filterComments(comments []sdk.PullRequestComments, startTime time.Time, botName string) []reviewCommand {


### PR DESCRIPTION
The approve tips include two case:
1. show the unapproved files and corresponding owner files
2. show the approver number